### PR TITLE
Add api endpoints

### DIFF
--- a/custom_components/zencharger/__init__.py
+++ b/custom_components/zencharger/__init__.py
@@ -16,7 +16,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-SET_CURRENT_SERVICE_NAME = "setCurrentLimit"
+SET_CURRENT_SERVICE_NAME = "set_current_limit"
 SET_CURRENT_SERVICE_SCHEMA = vol.Schema({
     vol.Required('current', default=6000): vol.All(int, vol.Range(min=1, max=32000)),
 })

--- a/custom_components/zencharger/__init__.py
+++ b/custom_components/zencharger/__init__.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SET_CURRENT_SERVICE_NAME = "setCurrentLimit"
 SET_CURRENT_SERVICE_SCHEMA = vol.Schema({
-    vol.Required('current', default=6000): vol.All(int, vol.Range(min=6000, max=32000)),
+    vol.Required('current', default=6000): vol.All(int, vol.Range(min=1, max=32000)),
 })
 
 type ZenchargerConfigEntry = ConfigEntry[ZenchargerApi]

--- a/custom_components/zencharger/services.yaml
+++ b/custom_components/zencharger/services.yaml
@@ -1,7 +1,7 @@
 # Example services.yaml entry
 
 # Service ID
-setCurrentLimit:
+set_current_limit:
   # Different fields that your service action accepts
   fields:
     # Key of the field

--- a/custom_components/zencharger/services.yaml
+++ b/custom_components/zencharger/services.yaml
@@ -1,0 +1,20 @@
+# Example services.yaml entry
+
+# Service ID
+setCurrentLimit:
+  # Different fields that your service action accepts
+  fields:
+    # Key of the field
+    current:
+      # Whether or not field is required (default = false)
+      required: true
+      # Example value that can be passed for this field
+      example: "6000"
+      # The default field value
+      default: "6000"
+      # Selector (https://www.home-assistant.io/docs/blueprint/selectors/) to control
+      # the input UI for this field
+      selector:
+        number:
+          min: 1
+          max: 32000

--- a/custom_components/zencharger/zencharger/api.py
+++ b/custom_components/zencharger/zencharger/api.py
@@ -4,6 +4,7 @@ import logging
 
 import httpx
 from requests import get
+import json
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -74,6 +75,20 @@ class ZenchargerApi:
 
     def updateUserConfig(self, config: any):
         return self.__request("patch", "config/user", config)
+
+
+    def updateCurrentLimit(self, new_value):
+        data = self.getSchedules()
+
+        for day, entries in data.items():
+            for entry in entries:
+                if entry["CurrentLimit"] != 0:
+                    entry["CurrentLimit"] = new_value
+
+        self.updateScheduledCharging(data);
+        self.updateUserConfig({
+            "ScheduledChargingEnable": True
+        })
 
     def __request(self, method: str, path: str, body: dict):
         """Perform POST or PATCH call to API"""

--- a/custom_components/zencharger/zencharger/api.py
+++ b/custom_components/zencharger/zencharger/api.py
@@ -64,24 +64,16 @@ class ZenchargerApi:
             raise ZenchargerApiError("Could not login with given credentials")
 
     def status(self) -> str:
-        """Get status from API."""
+        return self.__get("auth/status")
 
-        url = self._host + "/api/v1/auth/status"
-        headers = {
-            "accept": "application/json",
-        }
+    def getSchedules(self):
+        return self.__get("config/scheduledcharging/schedules")
 
-        try:
-            response = get(url, headers=headers, timeout=1.5)
-            response.raise_for_status()
+    def updateScheduledCharging(self, chargingSchedule):
+        return self.__request("post", "config/scheduledcharging/schedules", chargingSchedule)
 
-            if "Set-Cookie" in response.headers:
-                self._sessionId = response.headers["Set-Cookie"]
-                return response.headers.get("Set-Cookie")
-
-            raise ZenchargerApiError("Could not get status")
-        except Exception as error:
-            raise ZenchargerApiError("Could not get status")
+    def updateUserConfig(self, config: any):
+        return self.__request("patch", "config/user", config)
 
     def __request(self, method: str, path: str, body: dict):
         """Perform POST or PATCH call to API"""

--- a/custom_components/zencharger/zencharger/api.py
+++ b/custom_components/zencharger/zencharger/api.py
@@ -24,10 +24,11 @@ class ZenchargerApi:
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
         self._sessionId = None
+        self.cookies = None
         if isinstance(entry, dict):
             self._host = entry[CONF_DATA][CONF_CREDENTIALS][CONF_HOST]
             self._password = entry[CONF_DATA][CONF_CREDENTIALS][CONF_PASSWORD]
-        else:            
+        else:
             self._host = entry.data[CONF_CREDENTIALS][CONF_HOST]
             self._password = entry.data[CONF_CREDENTIALS][CONF_PASSWORD]
 
@@ -55,6 +56,7 @@ class ZenchargerApi:
 
             if "Set-Cookie" in response.headers:
                 self._sessionId = response.headers["Set-Cookie"]
+                self.cookies = response.cookies
                 return response.headers.get("Set-Cookie")
 
             raise ZenchargerApiError("Could not login with given credentials")
@@ -81,18 +83,23 @@ class ZenchargerApi:
         except Exception as error:
             raise ZenchargerApiError("Could not get status")
 
-    def _do_call(self, url: str, body: dict):
+    def __request(self, method: str, path: str, body: dict):
+        """Perform POST or PATCH call to API"""
         if self._sessionId is None:
             self.login()
 
+        url = self._host + "/api/v1/" + path
+
         headers = {
-            "accept": "application/json",
-            "xsrf-token": self._sessionId,
+            "accept": "application/json"
         }
 
         try:
-            response = httpx.post(url, headers=headers, json=body, timeout=5)
+            response = httpx.request(method, url, headers=headers, cookies=self.cookies, json=body, timeout=5)
             response.raise_for_status()
+            if not 'application/json' in response.headers.get('Content-Type', ''):
+                return None
+
             json_data = response.json()
 
             # Session Expired code?
@@ -106,9 +113,37 @@ class ZenchargerApi:
                     f"Retrieving the data for {url} failed with failCode: {json_data[ATTR_FAIL_CODE]}, message: {json_data[ATTR_DATA]}"
                 )
 
-            if ATTR_DATA not in json_data:
+            return json_data
+
+        except KeyError as error:
+            _LOGGER.error(error)
+            _LOGGER.error(response.text)
+
+    def __get(self, path: str):
+        """Perform GET call to API"""
+        if self._sessionId is None:
+            self.login()
+
+        url = self._host + "/api/v1/" + path
+
+        headers = {
+            "accept": "application/json"
+        }
+
+        try:
+            response = get(url, headers=headers, cookies=self.cookies, timeout=1.5)
+            response.raise_for_status()
+            json_data = response.json()
+
+            # Session Expired code?
+            if ATTR_FAIL_CODE in json_data and json_data[ATTR_FAIL_CODE] == 305:
+                # token expired
+                self._sessionId = None
+                return self._do_call(url, body)
+
+            if ATTR_FAIL_CODE in json_data and json_data[ATTR_FAIL_CODE] != 0:
                 raise ZenchargerApiError(
-                    f"Retrieving the data failed. Raw response: {response.text}"
+                    f"Retrieving the data for {url} failed with failCode: {json_data[ATTR_FAIL_CODE]}, message: {json_data[ATTR_DATA]}"
                 )
 
             return json_data


### PR DESCRIPTION
This PR will add new endpoints to the API client which allow you to fetch and update the charging schedule of the ZenCharger. First, I had to refactor the _get and _request private methods because they did not properly authenticate.

This wil also register a service in HA to update the schedule using a given current value (milli-ampères), which will update all schedule records of the API and update the current limit